### PR TITLE
Add supe.stop + supe.deregister apis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .nyc_output
+.DS_Store

--- a/lib/citizen.js
+++ b/lib/citizen.js
@@ -4,6 +4,7 @@ supe.supervised = true;
 supe.use = load_citizen_module;
 
 // load citizen core modules
+  supe.use( require('./modules/supervisor/hook') ); // behavior + api is identical for supervisor and citizen. why rewrite?
   supe.use( require('./modules/citizen/signal') );
   supe.use( require('./modules/citizen/mail') );
   supe.use( require('./modules/citizen/supervisor-noticeboard-bindings') );

--- a/lib/modules/citizen/mail/pause-mail.js
+++ b/lib/modules/citizen/mail/pause-mail.js
@@ -1,6 +1,6 @@
 module.exports = function( citizen, config ){
 
   citizen.mail.pause = function pause_mail(){
-    citizen.signal( 'NOT-READY-TO-RECEIVE-MAIL' );
+    citizen.signal.send( 'NOT-READY-TO-RECEIVE-MAIL' );
   }
 }

--- a/lib/modules/citizen/mail/receive-mail.js
+++ b/lib/modules/citizen/mail/receive-mail.js
@@ -10,7 +10,7 @@ module.exports = function( citizen, config ){
       if( !envelope.type || envelope.type !== 'mail' ) return;
       if( typeof current_receive_callback !== 'function' ) return;
 
-      current_receive_callback( envelope, function(){ citizen.signal( 'ACK-CURRENT-MAIL' ); } );
+      current_receive_callback( envelope, function(){ citizen.signal.send( 'ACK-CURRENT-MAIL' ); } );
     });
 
     setup_listener = true;
@@ -22,6 +22,6 @@ module.exports = function( citizen, config ){
 
     if( receive_callback && typeof receive_callback === 'function' ) current_receive_callback = receive_callback;
 
-    citizen.signal( 'READY-TO-RECEIVE-MAIL' );
+    citizen.signal.send( 'READY-TO-RECEIVE-MAIL' );
   }
 }

--- a/lib/modules/citizen/signal/index.js
+++ b/lib/modules/citizen/signal/index.js
@@ -1,14 +1,12 @@
-module.exports = function( interface, config ){
-  
-  interface.signal = function send_signal( signal, data ){
+var require_dir = require( 'require-directory' );
 
-    if( !signal ) return;
-    if( typeof signal !== 'string' ) throw new Error( 'signal must be a string' );
+module.exports = function( citizen, config ){
 
-    var envelope = { type: 'signal', signal: signal };
+  citizen.signal = {};
 
-    if( data ) envelope.data = data;
+  require_dir( module, { visit: run_found_module, recursive: false });
 
-    process.send( envelope );
+  function run_found_module( found ){
+    found( citizen, config );
   }
 }

--- a/lib/modules/citizen/signal/receive-watch-ignore-signals.js
+++ b/lib/modules/citizen/signal/receive-watch-ignore-signals.js
@@ -12,6 +12,7 @@ module.exports = function( supe, config ){
       var signal_name = msg.signal,
           signal_data = msg.data;
 
+      console.log('running hooks for signal: ' + signal_name );
       signal_hooks.run( signal_name, signal_data );
     });
 

--- a/lib/modules/citizen/signal/receive-watch-ignore-signals.js
+++ b/lib/modules/citizen/signal/receive-watch-ignore-signals.js
@@ -12,8 +12,6 @@ module.exports = function( supe, config ){
       var signal_name = msg.signal,
           signal_data = msg.data;
 
-      if( ! signal_hooks[ signal_name ] ) return;
-
       signal_hooks.run( signal_name, signal_data );
     });
 

--- a/lib/modules/citizen/signal/receive-watch-ignore-signals.js
+++ b/lib/modules/citizen/signal/receive-watch-ignore-signals.js
@@ -1,0 +1,34 @@
+var signal_hooks = require('cjs-sync-hooks')();
+
+module.exports = function( supe, config ){
+
+  supe.signal.watch = watch_signal;
+  supe.signal.ignore = ignore_signal;
+
+  // receive signals
+    process.on( 'message', function( msg ){
+      if( ! msg.type || msg.type !== 'signal' ) return;
+
+      var signal_name = msg.signal,
+          signal_data = msg.data;
+
+      if( ! signal_hooks[ signal_name ] ) return;
+
+      signal_hooks.run( signal_name, signal_data );
+    });
+
+  function watch_signal( signal_name, watcher_name, callback ){
+    if( ! signal_name || typeof signal_name !== 'string' ) throw new Error( 'signal name must be a string' );
+    if( ! watcher_name || typeof watcher_name !== 'string' ) throw new Error( 'watcher name must be a string' );
+    if( ! callback || typeof callback !== 'function' ) throw new Error( 'watcher callback must be a function' );
+
+    return signal_hooks.add( signal_name, watcher_name, callback );
+  }
+
+  function ignore_signal( signal_name, watcher_name ){
+    if( ! signal_name || typeof signal_name !== 'string' ) throw new Error( 'signal name must be a string' );
+    if( ! watcher_name || typeof watcher_name !== 'string' ) throw new Error( 'watcher name must be a string' );
+
+    return signal_hooks.del( signal_name, watcher_name );
+  }
+}

--- a/lib/modules/citizen/signal/send-signal.js
+++ b/lib/modules/citizen/signal/send-signal.js
@@ -1,0 +1,14 @@
+module.exports = function( citizen, config ){
+
+  citizen.signal.send = function send_signal( signal, data ){
+
+    if( !signal ) return;
+    if( typeof signal !== 'string' ) throw new Error( 'signal must be a string' );
+
+    var envelope = { type: 'signal', signal: signal };
+
+    if( data ) envelope.data = data;
+
+    process.send( envelope );
+  }
+}

--- a/lib/modules/citizen/supervision/handle-shutdown-signal.js
+++ b/lib/modules/citizen/supervision/handle-shutdown-signal.js
@@ -1,0 +1,27 @@
+var shutdown_initiated = false,
+    delays = 0;
+
+module.exports = function( citizen, config ){
+  
+  citizen.signal.watch( 'SUPE-SHUTDOWN', 'supe-initiate-shutdown', function(){
+    if( shutdown_initiated ) return;
+    else shutdown_initiated = true;
+
+    citizen.hook.run( 'shutdown', delay_shutdown );
+
+    if( ! delays ) return process.exit();
+
+    setTimeout( process.exit, 1000 * 3, new Error( 'shutdown delay exceeded maximum duration (3s)' ) );
+  });
+
+  function delay_shutdown(){
+    delays += 1;
+    return clear_delay;
+  }
+
+  function clear_delay(){
+    delays -= 1;
+
+    if( !delays ) process.exit();
+  }
+}

--- a/lib/modules/citizen/supervision/handle-shutdown-signal.js
+++ b/lib/modules/citizen/supervision/handle-shutdown-signal.js
@@ -8,10 +8,7 @@ module.exports = function( citizen, config ){
     else shutdown_initiated = true;
 
     citizen.hook.run( 'shutdown', delay_shutdown );
-
     if( ! delays ) return process.exit();
-
-    setTimeout( process.exit, 1000 * 3, new Error( 'shutdown delay exceeded maximum duration (3s)' ) );
   });
 
   function delay_shutdown(){

--- a/lib/modules/citizen/supervision/handle-shutdown-signal.js
+++ b/lib/modules/citizen/supervision/handle-shutdown-signal.js
@@ -18,7 +18,6 @@ module.exports = function( citizen, config ){
 
   function clear_delay(){
     delays -= 1;
-
-    if( !delays ) process.exit();
+    if( ! delays ) process.exit();
   }
 }

--- a/lib/modules/citizen/supervisor-noticeboard-bindings/ignore-notice.js
+++ b/lib/modules/citizen/supervisor-noticeboard-bindings/ignore-notice.js
@@ -8,6 +8,6 @@ module.exports = function( citizen, noticeboard, config ){
 
     if( noticeboard.watchers[ notice ] && noticeboard.watchers[ notice ].length > 0 ) return;
 
-    citizen.signal( 'NOTICEBOARD-REQUEST', { type: 'ignore', notice: notice });
+    citizen.signal.send( 'NOTICEBOARD-REQUEST', { type: 'ignore', notice: notice });
   }  
 }

--- a/lib/modules/citizen/supervisor-noticeboard-bindings/send-notice.js
+++ b/lib/modules/citizen/supervisor-noticeboard-bindings/send-notice.js
@@ -4,6 +4,6 @@ module.exports = function( citizen, noticeboard, config ){
 
   function notify_wrapper( notice, message, source ){
 
-    citizen.signal( 'NOTICEBOARD-REQUEST', { type: 'notify', notice: notice, message: message, source: source });
+    citizen.signal.send( 'NOTICEBOARD-REQUEST', { type: 'notify', notice: notice, message: message, source: source });
   }
 }

--- a/lib/modules/citizen/supervisor-noticeboard-bindings/watch-notice.js
+++ b/lib/modules/citizen/supervisor-noticeboard-bindings/watch-notice.js
@@ -53,7 +53,7 @@ module.exports = function( citizen, noticeboard, config ){
           }
         };
 
-        citizen.signal( 'NOTICEBOARD-REQUEST', citizen.noticeboard.pending[ notice ] );
+        citizen.signal.send( 'NOTICEBOARD-REQUEST', citizen.noticeboard.pending[ notice ] );
       }
   }
 }

--- a/lib/modules/supervisor/signal/create-signal-deps-on-citizen-registration.js
+++ b/lib/modules/supervisor/signal/create-signal-deps-on-citizen-registration.js
@@ -8,7 +8,7 @@ module.exports = function( supervisor, config ){
     function send_signal( signal_name, data ){
       if( !signal_name || typeof signal_name !== 'string' ) return;
 
-      var signal = { type: 'signal', signal: signal_name, from: citizen.name };
+      var signal = { type: 'signal', signal: signal_name };
       if( data ) signal.data = data;
 
       try {

--- a/lib/modules/supervisor/supervision/deregister-citizen.js
+++ b/lib/modules/supervisor/supervision/deregister-citizen.js
@@ -15,7 +15,7 @@ module.exports = function( supervisor, citizens, config ){
   }
 
   function deregister_citizen( name ){
-    return new Promise(function ( accept, reject ) {
+    return new Promise( function ( accept, reject ) {
       // if unregistered, reject
         if( ! supervisor.is_registered( name ) )
           return reject( new Error( 'no citizen named "' + name + '" has been registed' ) );
@@ -23,10 +23,10 @@ module.exports = function( supervisor, citizens, config ){
       // if citizen is not running then complete
         if( citizens[ name ].ref )
           return supervisor.stop( name )
-            .then(() => perform_deregister_citizen( accept, reject, name ))
-            .catch(reject);
+            .then( () => perform_deregister_citizen( accept, reject, name ) )
+            .catch( reject );
 
       return perform_deregister_citizen( accept, reject, name );
-    });
+    }) ;
   }
 }

--- a/lib/modules/supervisor/supervision/deregister-citizen.js
+++ b/lib/modules/supervisor/supervision/deregister-citizen.js
@@ -15,7 +15,7 @@ module.exports = function( supervisor, citizens, config ){
   }
 
   function deregister_citizen( name ){
-    return new Promise(function (accept, reject) {
+    return new Promise(function ( accept, reject ) {
       // if unregistered, reject
         if( ! supervisor.is_registered( name ) )
           return reject( new Error( 'no citizen named "' + name + '" has been registed' ) );

--- a/lib/modules/supervisor/supervision/deregister-citizen.js
+++ b/lib/modules/supervisor/supervision/deregister-citizen.js
@@ -3,7 +3,7 @@ module.exports = function( supervisor, citizens, config ){
   supervisor.deregister = deregister_citizen;
 
   function perform_deregister_citizen( accept, reject, name ) {
-    citizen = supervisor.hook.run( 'citizen-deregistration', citizen );
+    supervisor.hook.run( 'citizen-deregistration', citizens[ name ] );
 
     delete citizens[ name ];
 

--- a/lib/modules/supervisor/supervision/deregister-citizen.js
+++ b/lib/modules/supervisor/supervision/deregister-citizen.js
@@ -1,0 +1,32 @@
+module.exports = function( supervisor, citizens, config ){
+
+  supervisor.deregister = deregister_citizen;
+
+  function perform_deregister_citizen( accept, reject, name ) {
+    citizen = supervisor.hook.run( 'citizen-deregistration', citizen );
+
+    delete citizens[ name ];
+
+    // deregistration complete
+      supervisor.noticeboard.notify( 'citizen-deregistered', { name: name });
+      supervisor.noticeboard.notify( name + '-deregistered' );
+
+    return accept();
+  }
+
+  function deregister_citizen( name ){
+    return new Promise(function (accept, reject) {
+      // if unregistered, reject
+        if( ! supervisor.is_registered( name ) )
+          return reject( new Error( 'no citizen named "' + name + '" has been registed' ) );
+
+      // if citizen is not running then complete
+        if( citizens[ name ].ref )
+          return supervisor.stop( name )
+            .then(() => perform_deregister_citizen( accept, reject, name ))
+            .catch(reject);
+
+      return perform_deregister_citizen( accept, reject, name );
+    });
+  }
+}

--- a/lib/modules/supervisor/supervision/deregister-citizen.js
+++ b/lib/modules/supervisor/supervision/deregister-citizen.js
@@ -2,31 +2,33 @@ module.exports = function( supervisor, citizens, config ){
 
   supervisor.deregister = deregister_citizen;
 
-  function perform_deregister_citizen( accept, reject, name ) {
-    supervisor.hook.run( 'citizen-deregistration', citizens[ name ] );
+  function deregister_citizen( name ){
+    // if unregistered, throw error
+      if( ! supervisor.is_registered( name ) ) throw new Error( 'no citizen named "' + name + '" has been registed' );
 
-    delete citizens[ name ];
+    var citizen_is_running = citizens[ name ].ref ? true : false;
 
-    // deregistration complete
+    // deregister if citizen is not running
+      if( ! citizen_is_running ) return perform_deregister( name );
+      if( citizens[ name ].state.deregistering ) return;
+
+    // else stop then deregister
+      citizens[ name ].state.deregistering = true;
+
+      supervisor.noticeboard.once( name + '-stopped', 'complete-'+ name +'-deregistration', function(){
+        perform_deregister( name );
+      });
+
+      supervisor.stop( name );
+
+    function perform_deregister( name ) {
+      supervisor.hook.run( name + '-deregistering', citizens[ name ] );
+      supervisor.hook.run( 'citizen-deregistering', citizens[ name ] );
+
+      delete citizens[ name ];
+
       supervisor.noticeboard.notify( 'citizen-deregistered', { name: name });
       supervisor.noticeboard.notify( name + '-deregistered' );
-
-    return accept();
-  }
-
-  function deregister_citizen( name ){
-    return new Promise( function ( accept, reject ) {
-      // if unregistered, reject
-        if( ! supervisor.is_registered( name ) )
-          return reject( new Error( 'no citizen named "' + name + '" has been registed' ) );
-
-      // if citizen is not running then complete
-        if( citizens[ name ].ref )
-          return supervisor.stop( name )
-            .then( () => perform_deregister_citizen( accept, reject, name ) )
-            .catch( reject );
-
-      return perform_deregister_citizen( accept, reject, name );
-    }) ;
+    }
   }
 }

--- a/lib/modules/supervisor/supervision/notify-on-crash-or-shutdown.js
+++ b/lib/modules/supervisor/supervision/notify-on-crash-or-shutdown.js
@@ -6,7 +6,7 @@ module.exports = function( supervisor ){
 
       delete citizen.ref;
 
-      if( code === 0 ){                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+      if( code === 0 ){
         supervisor.noticeboard.notify( 'citizen-shutdown', { name: citizen.name });
         supervisor.noticeboard.notify( citizen.name + '-shutdown' );
       }
@@ -14,7 +14,7 @@ module.exports = function( supervisor ){
       else{
         supervisor.noticeboard.notify( 'citizen-crashed', { name: citizen.name });
         supervisor.noticeboard.notify( citizen.name + '-crashed' );
-      } 
+      }
     });
   });
 }

--- a/lib/modules/supervisor/supervision/notify-on-crash-or-shutdown.js
+++ b/lib/modules/supervisor/supervision/notify-on-crash-or-shutdown.js
@@ -6,12 +6,12 @@ module.exports = function( supervisor ){
 
       delete citizen.ref;
 
-      if( code === 0 ){
+      if( code === 0 || code == null ){
         supervisor.noticeboard.notify( 'citizen-shutdown', { name: citizen.name });
         supervisor.noticeboard.notify( citizen.name + '-shutdown' );
       }
 
-      else if ( code !== null ){
+      else {
         supervisor.noticeboard.notify( 'citizen-crashed', { name: citizen.name });
         supervisor.noticeboard.notify( citizen.name + '-crashed' );
       }

--- a/lib/modules/supervisor/supervision/notify-on-crash-or-shutdown.js
+++ b/lib/modules/supervisor/supervision/notify-on-crash-or-shutdown.js
@@ -11,7 +11,7 @@ module.exports = function( supervisor ){
         supervisor.noticeboard.notify( citizen.name + '-shutdown' );
       }
 
-      else{
+      else if ( code !== null ){
         supervisor.noticeboard.notify( 'citizen-crashed', { name: citizen.name });
         supervisor.noticeboard.notify( citizen.name + '-crashed' );
       }

--- a/lib/modules/supervisor/supervision/register-citizen.js
+++ b/lib/modules/supervisor/supervision/register-citizen.js
@@ -5,39 +5,37 @@ module.exports = function( supervisor, citizens, config ){
   supervisor.register = register_citizen;
 
   function register_citizen( name, file, params ){
-    return new Promise( function ( accept, reject ) {
-      // filter bad input
-        if( !name ) return reject( new Error( 'requires a name to refer to supervised process' ) );
-        if( !file ) return reject( new Error( 'requires path to file to run to supervised process' ) );
-        if( typeof name !== 'string' ) return reject( new Error( 'name must be a string' ) );
-        if( typeof file !== 'string' ) return reject( new Error( 'path to file must be a string' ) );
-        if( !params ) params = {};
+    // filter bad input
+      if( !name ) throw new Error( 'requires a name to refer to supervised process' );
+      if( !file ) throw new Error( 'requires path to file to run to supervised process' );
+      if( typeof name !== 'string' ) throw new Error( 'name must be a string' );
+      if( typeof file !== 'string' ) throw new Error( 'path to file must be a string' );
+      if( !params ) params = {};
 
-      // ensure citizen name isn't already taken
-        if( supervisor.is_registered( name ) ){
+    // ensure citizen name isn't already taken
+      if( supervisor.is_registered( name ) ){
 
-          if( citizens[ name ].file === file ) return accept( citizens[ name ] );
-          else return reject( new Error( 'a citizen named "' + name + '" already exists' ) );
-        }
+        if( citizens[ name ].file === file ) return citizens[ name ];
+        else throw new Error( 'a citizen named "' + name + '" already exists' );
+      }
 
-      // store citizen in map
-        citizens[ name ] = {
+    // store citizen in map
+      citizens[ name ] = {
 
-          name: name,
-          file: file,
-          state: {},
+        name: name,
+        file: file,
+        state: {},
 
-          config: merge( { retries: config.retries, duration: config.duration }, params )
-        };
+        config: merge( { retries: config.retries, duration: config.duration }, params )
+      };
 
-      // customize citizen instance
-        citizens[ name ] = supervisor.hook.run( 'citizen-registration', citizens[ name ] );
+    // customize citizen instance
+      citizens[ name ] = supervisor.hook.run( 'citizen-registration', citizens[ name ] );
 
-      // registration complete
-        supervisor.noticeboard.notify( 'citizen-registered', { name: name });
-        supervisor.noticeboard.notify( name + '-registered' );
+    // registration complete
+      supervisor.noticeboard.notify( 'citizen-registered', { name: name });
+      supervisor.noticeboard.notify( name + '-registered' );
 
-      return accept( citizens[ name ] );
-    } );
+    return citizens[ name ];
   }
 }

--- a/lib/modules/supervisor/supervision/register-citizen.js
+++ b/lib/modules/supervisor/supervision/register-citizen.js
@@ -27,7 +27,7 @@ module.exports = function( supervisor, citizens, config ){
           file: file,
           state: {},
 
-          config: merge({ retries: config.retries, duration: config.duration }, params )
+          config: merge( { retries: config.retries, duration: config.duration }, params )
         };
 
       // customize citizen instance

--- a/lib/modules/supervisor/supervision/register-citizen.js
+++ b/lib/modules/supervisor/supervision/register-citizen.js
@@ -1,42 +1,43 @@
 var merge = require('merge-objects');
 
 module.exports = function( supervisor, citizens, config ){
-  
+
   supervisor.register = register_citizen;
 
   function register_citizen( name, file, params ){
+    return new Promise( function (accept, reject) {
+      // filter bad input
+        if( !name ) return reject( new Error( 'requires a name to refer to supervised process' ) );
+        if( !file ) return reject( new Error( 'requires path to file to run to supervised process' ) );
+        if( typeof name !== 'string' ) return reject( new Error( 'name must be a string' ) );
+        if( typeof file !== 'string' ) return reject( new Error( 'path to file must be a string' ) );
+        if( !params ) params = {};
 
-    // filter bad input
-      if( !name ) throw new Error( 'requires a name to refer to supervised process' );
-      if( !file ) throw new Error( 'requires path to file to run to supervised process' );
-      if( typeof name !== 'string' ) throw new Error( 'name must be a string' );
-      if( typeof file !== 'string' ) throw new Error( 'path to file must be a string' );
-      if( !params ) params = {};
+      // ensure citizen name isn't already taken
+        if( supervisor.is_registered( name ) ){
 
-    // ensure citizen name isn't already taken 
-      if( supervisor.is_registered( name ) ){
+          if( citizens[ name ].file === file ) return accept( citizens[ name ] );
+          else return reject( new Error( 'a citizen named "' + name + '" already exists' ) );
+        }
 
-        if( citizens[ name ].file === file ) return citizens[ name ];
-        else throw new Error( 'a citizen named "' + name + '" already exists' ); 
-      }
+      // store citizen in map
+        citizens[ name ] = {
 
-    // store citizen in map
-      citizens[ name ] = {
+          name: name,
+          file: file,
+          state: {},
 
-        name: name,
-        file: file,
-        state: {},
+          config: merge({ retries: config.retries, duration: config.duration }, params )
+        };
 
-        config: merge({ retries: config.retries, duration: config.duration }, params )
-      };
+      // customize citizen instance
+        citizens[ name ] = supervisor.hook.run( 'citizen-registration', citizens[ name ] );
 
-    // customize citizen instance
-      citizens[ name ] = supervisor.hook.run( 'citizen-registration', citizens[ name ] );
+      // registration complete
+        supervisor.noticeboard.notify( 'citizen-registered', { name: name });
+        supervisor.noticeboard.notify( name + '-registered' );
 
-    // registration complete
-      supervisor.noticeboard.notify( 'citizen-registered', { name: name });
-      supervisor.noticeboard.notify( name + '-registered' );
-
-    return citizens[ name ];
+      return accept( citizens[ name ] );
+    } );
   }
 }

--- a/lib/modules/supervisor/supervision/register-citizen.js
+++ b/lib/modules/supervisor/supervision/register-citizen.js
@@ -5,7 +5,7 @@ module.exports = function( supervisor, citizens, config ){
   supervisor.register = register_citizen;
 
   function register_citizen( name, file, params ){
-    return new Promise( function (accept, reject) {
+    return new Promise( function ( accept, reject ) {
       // filter bad input
         if( !name ) return reject( new Error( 'requires a name to refer to supervised process' ) );
         if( !file ) return reject( new Error( 'requires path to file to run to supervised process' ) );

--- a/lib/modules/supervisor/supervision/start-citizen.js
+++ b/lib/modules/supervisor/supervision/start-citizen.js
@@ -4,15 +4,14 @@ module.exports = function( supervisor, citizens, config ){
 
   supervisor.start = start_citizen;
 
-  function perform_start_citizen ( accept, reject, name, file, params ) {
+  function start_citizen( name, file, params ){
     // specified filepath doesn't match registered citizen's filepath? something is wrong
-      if( file && file !== citizens[ name ].file )
-        return reject( new Error( 'citizen named "' + name + '" already exists' ) );
+      if( file && file !== citizens[ name ].file ) throw new Error( 'citizen named "' + name + '" already exists' );
 
     var citizen = citizens[ name ];
 
     // bail if citizen is already running
-      if( citizen.ref ) return reject( new Error( 'citizen named "' + name + '" already exists and is running' ) );
+      if( citizen.ref ) return throw new Error( 'citizen named "' + name + '" already exists and is running' );
 
     // modify copy of current env for citizen
       var citizen_env = JSON.parse( JSON.stringify( process.env ) );
@@ -30,18 +29,6 @@ module.exports = function( supervisor, citizens, config ){
     supervisor.noticeboard.notify( name + '-started' );
     supervisor.noticeboard.notify( 'citizen-started', { name: name });
 
-    return accept(citizen);
-  }
-
-  function start_citizen( name, file, params ){
-    return new Promise( function ( accept, reject ) {
-      // if unregistered, register citizen now
-        if( ! supervisor.is_registered( name ) )
-          return supervisor.register( name, file, params )
-          .then( () => perform_start_citizen( accept, reject, name, file, params ) )
-          .catch( reject );
-
-      return perform_start_citizen( accept, reject, name, file, params );
-    } );
+    return citizen;
   }
 }

--- a/lib/modules/supervisor/supervision/start-citizen.js
+++ b/lib/modules/supervisor/supervision/start-citizen.js
@@ -5,13 +5,18 @@ module.exports = function( supervisor, citizens, config ){
   supervisor.start = start_citizen;
 
   function start_citizen( name, file, params ){
+
+    // if unregistered, register citizen now
+      if( ! supervisor.is_registered( name ) )
+        supervisor.register( name, file, params );
+
     // specified filepath doesn't match registered citizen's filepath? something is wrong
       if( file && file !== citizens[ name ].file ) throw new Error( 'citizen named "' + name + '" already exists' );
 
     var citizen = citizens[ name ];
 
     // bail if citizen is already running
-      if( citizen.ref ) return throw new Error( 'citizen named "' + name + '" already exists and is running' );
+      if( citizen.ref ) throw new Error( 'citizen named "' + name + '" already exists and is running' );
 
     // modify copy of current env for citizen
       var citizen_env = JSON.parse( JSON.stringify( process.env ) );

--- a/lib/modules/supervisor/supervision/start-citizen.js
+++ b/lib/modules/supervisor/supervision/start-citizen.js
@@ -31,14 +31,14 @@ module.exports = function( supervisor, citizens, config ){
   }
 
   function start_citizen( name, file, params ){
-    return new Promise(function ( accept, reject ) {
+    return new Promise( function ( accept, reject ) {
       // if unregistered, register citizen now
         if( ! supervisor.is_registered( name ) )
           return supervisor.register( name, file, params )
-          .then(() => perform_start_citizen( accept, reject, name, file, params ))
+          .then( () => perform_start_citizen( accept, reject, name, file, params ) )
           .catch( reject );
 
       return perform_start_citizen( accept, reject, name, file, params );
-    });
+    } );
   }
 }

--- a/lib/modules/supervisor/supervision/start-citizen.js
+++ b/lib/modules/supervisor/supervision/start-citizen.js
@@ -4,20 +4,15 @@ module.exports = function( supervisor, citizens, config ){
 
   supervisor.start = start_citizen;
 
-  function start_citizen( name, file, params ){
-
-    // if unregistered, register citizen now
-      if( ! supervisor.is_registered( name ) )
-        supervisor.register( name, file, params );
-
+  function perform_start_citizen ( accept, reject, name, file, params ) {
     // specified filepath doesn't match registered citizen's filepath? something is wrong
       if( file && file !== citizens[ name ].file )
-        throw new Error( 'citizen named "' + name + '" already exists' );
+        return reject( new Error( 'citizen named "' + name + '" already exists' ) );
 
     var citizen = citizens[ name ];
 
     // bail if citizen is already running
-      if( citizen.ref ) return;
+      if( citizen.ref ) return reject( new Error( 'citizen named "' + name + '" already exists and is running' ) );
 
     // spawn citizen process
       citizen.ref = child_process.spawn( 'node', [ citizens[ name ].file ], {
@@ -32,6 +27,18 @@ module.exports = function( supervisor, citizens, config ){
     supervisor.noticeboard.notify( name + '-started' );
     supervisor.noticeboard.notify( 'citizen-started', { name: name });
 
-    return citizen;
-  }  
+    return accept(citizen);
+  }
+
+  function start_citizen( name, file, params ){
+    return new Promise(function (accept, reject) {
+      // if unregistered, register citizen now
+        if( ! supervisor.is_registered( name ) )
+          return supervisor.register( name, file, params )
+          .then(() => perform_start_citizen( accept, reject, name, file, params ))
+          .catch( reject );
+
+      return perform_start_citizen( accept, reject, name, file, params );
+    });
+  }
 }

--- a/lib/modules/supervisor/supervision/start-citizen.js
+++ b/lib/modules/supervisor/supervision/start-citizen.js
@@ -31,7 +31,7 @@ module.exports = function( supervisor, citizens, config ){
   }
 
   function start_citizen( name, file, params ){
-    return new Promise(function (accept, reject) {
+    return new Promise(function ( accept, reject ) {
       // if unregistered, register citizen now
         if( ! supervisor.is_registered( name ) )
           return supervisor.register( name, file, params )

--- a/lib/modules/supervisor/supervision/stop-citizen.js
+++ b/lib/modules/supervisor/supervision/stop-citizen.js
@@ -3,22 +3,45 @@ module.exports = function( supervisor, citizens, config ){
   supervisor.stop = stop_citizen;
 
   function stop_citizen( name ){
+    if( ! name ) throw new Error( 'no citizen name given' );
+    if( typeof name !== 'string' ) throw new Error( 'citizen name given must be a string' );
+
     // if unregistered, reject
       if( ! supervisor.is_registered( name ) ) throw new Error( 'no citizen named "' + name + '" has been registed' );
 
-    var citizen = citizens[ name ];
+    var citizen = citizens[ name ],
+        stop_confirmed = false,
+        stop_request_timeout;
 
-    // bail if citizen is not running
+    // bail if citizen is stopping or not running
+      if( citizen.state.stopping ) return;
       if( ! citizen.ref ) return;
 
+    citizen.state.stopping = true;
+
+    citizen = supervisor.hook.run( name + '-stopping', citizen );
     citizen = supervisor.hook.run( 'citizen-stopping', citizen );
 
-    citizen.ref.kill('SIGHUP');
+    supervisor.noticeboard.once( name + '-shutdown', 'supe-confirm-citizen-stop', confirm_citizen_stop );
+    supervisor.noticeboard.once( name + '-crashed', 'supe-confirm-citizen-stop', confirm_citizen_stop );
 
-    delete citizen.ref;
+    citizen.signal.send( 'SUPE-SHUTDOWN' );
 
-    citizens[ name ] = citizen;
+    setTimeout( function(){
+      if( stop_confirmed || ! citizen.state.stopping ) return;
+      citizen.ref.kill();
+    }, 1000 * 8 );
 
     return citizens[ name ];
+
+    function confirm_citizen_stop(){
+      if( stop_confirmed ) return;
+
+      citizen.state.stopping = false;
+      supervisor.noticeboard.notify( 'citizen-stopped', { name: name });
+      supervisor.noticeboard.notify( name + '-stopped' );
+
+      stop_confirmed = true;
+    }
   }
 }

--- a/lib/modules/supervisor/supervision/stop-citizen.js
+++ b/lib/modules/supervisor/supervision/stop-citizen.js
@@ -22,15 +22,27 @@ module.exports = function( supervisor, citizens, config ){
     citizen = supervisor.hook.run( name + '-stopping', citizen );
     citizen = supervisor.hook.run( 'citizen-stopping', citizen );
 
+    // Graceful Shutdown Strategy
+
+    // 1. Send signal to citizen
+    //    to clean up and shut
+    //    themselves down.
+
     supervisor.noticeboard.once( name + '-shutdown', 'supe-confirm-citizen-stop', confirm_citizen_stop );
     supervisor.noticeboard.once( name + '-crashed', 'supe-confirm-citizen-stop', confirm_citizen_stop );
 
     citizen.signal.send( 'SUPE-SHUTDOWN' );
 
+    // 2. If citizen doesnt shut
+    //    down in grace time,
+    //    kill it.
+
+    var grace_time_ms = 1000 * 8;
+
     setTimeout( function(){
       if( stop_confirmed || ! citizen.state.stopping ) return;
       citizen.ref.kill();
-    }, 1000 * 8 );
+    }, grace_time_ms );
 
     return citizens[ name ];
 

--- a/lib/modules/supervisor/supervision/stop-citizen.js
+++ b/lib/modules/supervisor/supervision/stop-citizen.js
@@ -21,7 +21,7 @@ module.exports = function( supervisor, citizens, config ){
 
       citizens[ name ] = citizen;
 
-      return accept();
+      return accept( citizens[ name ] );
     } );
   }
 }

--- a/lib/modules/supervisor/supervision/stop-citizen.js
+++ b/lib/modules/supervisor/supervision/stop-citizen.js
@@ -3,25 +3,22 @@ module.exports = function( supervisor, citizens, config ){
   supervisor.stop = stop_citizen;
 
   function stop_citizen( name ){
-    return new Promise( function ( accept, reject ) {
-      // if unregistered, reject
-        if( ! supervisor.is_registered( name ) )
-          return reject( new Error( 'no citizen named "' + name + '" has been registed' ) );
+    // if unregistered, reject
+      if( ! supervisor.is_registered( name ) ) throw new Error( 'no citizen named "' + name + '" has been registed' );
 
-      var citizen = citizens[ name ];
+    var citizen = citizens[ name ];
 
-      // if citizen is not running then complete
-        if( ! citizen.ref ) return accept();
+    // bail if citizen is not running
+      if( ! citizen.ref ) return;
 
-      citizen = supervisor.hook.run( 'citizen-stoping', citizen );
+    citizen = supervisor.hook.run( 'citizen-stopping', citizen );
 
-      citizen.ref.kill('SIGHUP');
+    citizen.ref.kill('SIGHUP');
 
-      delete citizen.ref;
+    delete citizen.ref;
 
-      citizens[ name ] = citizen;
+    citizens[ name ] = citizen;
 
-      return accept( citizens[ name ] );
-    } );
+    return citizens[ name ];
   }
 }

--- a/lib/modules/supervisor/supervision/stop-citizen.js
+++ b/lib/modules/supervisor/supervision/stop-citizen.js
@@ -3,7 +3,7 @@ module.exports = function( supervisor, citizens, config ){
   supervisor.stop = stop_citizen;
 
   function stop_citizen( name ){
-    return new Promise(function (accept, reject) {
+    return new Promise( function ( accept, reject ) {
       // if unregistered, reject
         if( ! supervisor.is_registered( name ) )
           return reject( new Error( 'no citizen named "' + name + '" has been registed' ) );
@@ -20,6 +20,6 @@ module.exports = function( supervisor, citizens, config ){
       delete citizen.ref;
 
       return accept();
-    });
+    } );
   }
 }

--- a/lib/modules/supervisor/supervision/stop-citizen.js
+++ b/lib/modules/supervisor/supervision/stop-citizen.js
@@ -19,6 +19,8 @@ module.exports = function( supervisor, citizens, config ){
 
       delete citizen.ref;
 
+      citizens[ name ] = citizen;
+
       return accept();
     } );
   }

--- a/lib/modules/supervisor/supervision/stop-citizen.js
+++ b/lib/modules/supervisor/supervision/stop-citizen.js
@@ -1,0 +1,25 @@
+module.exports = function( supervisor, citizens, config ){
+
+  supervisor.stop = stop_citizen;
+
+  function stop_citizen( name ){
+    return new Promise(function (accept, reject) {
+      // if unregistered, reject
+        if( ! supervisor.is_registered( name ) )
+          return reject( new Error( 'no citizen named "' + name + '" has been registed' ) );
+
+      var citizen = citizens[ name ];
+
+      // if citizen is not running then complete
+        if( ! citizen.ref ) return accept();
+
+      citizen = supervisor.hook.run( 'citizen-stoping', citizen );
+
+      citizen.ref.kill('SIGHUP');
+
+      delete citizen.ref;
+
+      return accept();
+    });
+  }
+}

--- a/test/citizen/shutdown-ignorer.js
+++ b/test/citizen/shutdown-ignorer.js
@@ -1,0 +1,12 @@
+var supe = require('../../index');
+
+supe.hook.add( 'shutdown', 'refuse-to-shutdown', function( delay_shutdown ){
+  console.log( 'hooked into shutdown sequence' );
+
+  var release_delay = delay_shutdown();
+  console.log( 'requested shutdown delay. release key:', release_delay );
+
+  // hold release indefinitely
+});
+
+console.log( 'added shutdown hook that holds release indefinitely' );

--- a/test/test.js
+++ b/test/test.js
@@ -178,6 +178,43 @@ describe('Supe Test Suite', function(){
       });
     });
 
+    describe('Supervisor.deregister', function(){
+      var supervisor = supe(),
+          citizen_name = 'citizen-to-deregister';
+
+      afterEach( function(){
+        if( supervisor.get( citizen_name ) ) supervisor.deregister( citizen_name );
+        supervisor = supe();
+      });
+
+      it('will remove a citizen from supe\'s registry', function(){
+        supervisor.register( citizen_name, './test/citizen/interval-logger' );
+        supervisor.deregister( citizen_name );
+
+        assert.equal( supervisor.get( citizen_name ), false, 'citizen still exists' );
+      });
+
+      it('will stop a running citizen before deregistering it', function(){
+        var stopped = false;
+
+        supervisor.start( citizen_name, './test/citizen/interval-logger' );
+
+        supervisor.noticeboard.once( citizen_name + '-stopped', 'mark-stopped', function(){
+          stopped = true;
+        });
+
+        supervisor.noticeboard.once( citizen_name + '-deregistered', 'do-assertions', function(){
+          var citizen = supervisor.get( citizen_name ),
+              citizen_exists = citizen && citizen != false && citizen != null;
+
+          assert.equal( citizen_exists, false, 'citizen was not deregistered' );
+          assert.equal( stopped, true, 'citizen was not stopped' );
+        });
+
+        supervisor.deregister( citizen_name );
+      });
+    });
+
     describe('Supervisor.start', function(){
       var supervisor,
           new_process; 

--- a/test/test.js
+++ b/test/test.js
@@ -329,6 +329,35 @@ describe('Supe Test Suite', function(){
 
         supervisor.start( citizen_name  );
       });
+
+      it('throws error if given name is not a string', function(){
+        var non_strings = [ 1, {}, [], null, false, NaN ],
+            errors_thrown = 0;
+
+        non_strings.forEach( function( non_string ){
+          try {
+            supervisor.stop( non_string );
+          }
+          catch(e){
+            errors_thrown += 1;
+          }
+        });
+
+        assert.equal( errors_thrown == non_strings.length, true, 'errors thrown does not match number of non strings tested' );
+      });
+
+      it('throws error if citizen with given name does not exist', function(){
+        var error_thrown = false;
+
+        try{
+          supervisor.stop( 'non-existent-citizen' );
+        }
+        catch(e) {
+          error_thrown = true;
+        }
+
+        assert.equal( error_thrown, true, 'no error thrown when stopping non-existent citizen' );
+      });
     });
 
     describe('Supervisor.get', function(){

--- a/test/test.js
+++ b/test/test.js
@@ -201,6 +201,50 @@ describe('Supe Test Suite', function(){
       });
     });
 
+    describe('Supervisor.deregister', function(){
+      var supervisor,
+          new_process;
+
+      beforeEach( function(){
+        supervisor = supe();
+        new_process = supervisor.register( 'logger', './test/citizen/interval-logger' );
+      } );
+
+      it('returns a Promsie', function( done ){
+        new_process
+        .then( () => {
+          assert.equal( supervisor.deregister( 'logger' ) instanceof Promise, true, 'did not return a Promise' );
+          setTimeout( done, 0 );
+        } );
+      });
+
+      it('removes a registed citizen', function( done ){
+        const citizen_name = 'logger';
+        new_process.then( () => {
+          assert.equal( supervisor.is_registered( citizen_name ), true, 'is not registerd the first time' );
+          supervisor.deregister( citizen_name )
+          .then( () => {
+            assert.equal( supervisor.is_registered( citizen_name ), false, 'citizen was not deregisterd' );
+            done();
+          })
+          .catch( () => done() );
+        } )
+        .catch( () => done() );
+      });
+
+      it('removes a running registed citizen', function( done ){
+        const citizen_name = 'logger';
+        new_process
+        .then( () => supervisor.start( citizen_name ) )
+        .then( () => supervisor.deregister( citizen_name ) )
+        .then( () => {
+          assert.equal( supervisor.is_registered( citizen_name ), false, 'citizen was not deregisterd' );
+          setTimeout( done, 0 ) ;
+        } )
+        .catch( () => setTimeout( done, 0 ) );
+      });
+    });
+
     describe('Supervisor.start', function(){
       var supervisor,
           new_process;
@@ -213,6 +257,11 @@ describe('Supe Test Suite', function(){
       afterEach( function(){
         supervisor.stop( 'logger' ).catch( () => {} );
         new_process = null;
+      });
+
+      it('returns a Promsie', function( done ){
+        assert.equal( new_process instanceof Promise, true, 'did not return a Promise' );
+        setTimeout( done, 0 );
       });
 
       it('citizen has a process reference ("ref" property)', function( done ){
@@ -261,6 +310,8 @@ describe('Supe Test Suite', function(){
         });
       });
     });
+
+
 
     describe('Supervisor.get', function(){
       var supervisor = supe();

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@ describe('Supe Test Suite', function(){
   describe('Supervisor (Instantiated Supe) Properties', function(){
 
     var supervisor = supe(),
-        expected_properties = [ 'is_registered', 'register', 'start', 'get', 'use', 'noticeboard', 'hook' ];
+        expected_properties = [ 'is_registered', 'register', 'deregister', 'start', 'stop', 'get', 'use', 'noticeboard', 'hook' ];
 
     it('has its own "is_registered" function', function(){
       assert.equal( supervisor.hasOwnProperty('is_registered') && typeof supervisor.is_registered === 'function', true, 'didn\'t instantiate with its own "is_registered" function');
@@ -24,8 +24,16 @@ describe('Supe Test Suite', function(){
       assert.equal( supervisor.hasOwnProperty('register') && typeof supervisor.register === 'function', true, 'didn\'t instantiate with its own "register" function');
     });
 
+    it('has its own "deregister" function', function(){
+      assert.equal( supervisor.hasOwnProperty('deregister') && typeof supervisor.deregister === 'function', true, 'didn\'t instantiate with its own "deregister" function');
+    });
+
     it('has its own "start" function', function(){
       assert.equal( supervisor.hasOwnProperty('start') && typeof supervisor.start === 'function', true, 'didn\'t instantiate with its own "start" function');
+    });
+
+    it('has its own "stop" function', function(){
+      assert.equal( supervisor.hasOwnProperty('stop') && typeof supervisor.stop === 'function', true, 'didn\'t instantiate with its own "stop" function');
     });
 
     it('has its own "get" function', function(){
@@ -86,7 +94,7 @@ describe('Supe Test Suite', function(){
 
     describe('Supervisor.register', function(){
       var supervisor,
-          new_process; 
+          new_process;
 
       beforeEach( function(){
         supervisor = supe();
@@ -159,8 +167,8 @@ describe('Supe Test Suite', function(){
         for( var prop in params ){
           if( !params.hasOwnProperty( prop ) ) continue;
 
-          assert.equal( citizen.config.hasOwnProperty( prop ), true, 'citizen config does not have expected property "' + prop + '"' );            
-          assert.equal( citizen.config[ prop ] === params[ prop ], true, 'parameter property "' + prop + '" does not match citizen config\'s "' + prop + '"' );            
+          assert.equal( citizen.config.hasOwnProperty( prop ), true, 'citizen config does not have expected property "' + prop + '"' );
+          assert.equal( citizen.config[ prop ] === params[ prop ], true, 'parameter property "' + prop + '" does not match citizen config\'s "' + prop + '"' );
         }
       });
 
@@ -173,9 +181,9 @@ describe('Supe Test Suite', function(){
       });
     });
 
-    describe('Supervisor.start', function(){      
+    describe('Supervisor.start', function(){
       var supervisor,
-          new_process; 
+          new_process;
 
       beforeEach( function(){
         supervisor = supe();
@@ -217,7 +225,7 @@ describe('Supe Test Suite', function(){
 
               supervisor.noticeboard.once( citizen_name + '-shutdown', 'restart-citizen', function(){
                 supervisor.start( citizen_name );
-              });              
+              });
             break;
 
             case 2:
@@ -229,7 +237,7 @@ describe('Supe Test Suite', function(){
               done();
 
               // cleanup
-                citizen.ref.kill();              
+                citizen.ref.kill();
             break;
 
             default:
@@ -345,7 +353,7 @@ describe('Supe Test Suite', function(){
 
   describe('Supervisor Noticeboard Integration', function(){
     var supervisor;
-    
+
     beforeEach( function(){
       supervisor = supe({ retries: 0 });
     });
@@ -365,7 +373,7 @@ describe('Supe Test Suite', function(){
 
     it('sends notice "citizen-registered" when any citizen is registered', function( done ){
       this.timeout( 10000 );
-      
+
       var first_citizen_name = 'first-crasher',
           second_citizen_name = 'second-crasher',
           registrations_detected = 0;
@@ -376,10 +384,10 @@ describe('Supe Test Suite', function(){
         var details = msg.notice;
 
         if( details.name !== second_citizen_name ) return;
-        
+
         assert.equal( registrations_detected === 2, true, 'did not detect all citizen registrations' );
         assert.equal( details.name === second_citizen_name, true, 'did not detect expected citizen registration' );
-        
+
         done();
       });
 
@@ -407,7 +415,7 @@ describe('Supe Test Suite', function(){
 
     it('sends notice "citizen-started" when any citizen is started', function( done ){
       this.timeout( 10000 );
-      
+
       var first_citizen_name = 'first-crasher',
           second_citizen_name = 'second-crasher',
           startups_detected = 0;
@@ -419,10 +427,10 @@ describe('Supe Test Suite', function(){
         var details = msg.notice;
 
         if( details.name !== second_citizen_name ) return;
-        
+
         assert.equal( startups_detected === 2, true, 'did not detect all citizen start' );
         assert.equal( details.name === second_citizen_name, true, 'did not detect expected citizen start' );
-        
+
         done();
       });
 
@@ -432,12 +440,12 @@ describe('Supe Test Suite', function(){
 
     it('sends notice "(name)-shutdown" when a citizen shuts down', function( done ){
       this.timeout( 15000 );
-      
+
       var detected_shutdown = false;
 
       supervisor.noticeboard.watch( 'one-time-logger-shutdown', 'do-assertions', function( msg ){
         detected_shutdown = true;
-        
+
         assert.equal( detected_shutdown === true, true, 'did not detect specific citizen shutdown' );
         done();
       });
@@ -447,7 +455,7 @@ describe('Supe Test Suite', function(){
 
     it('sends notice "citizen-shutdown" when any citizen shuts down', function( done ){
       this.timeout( 10000 );
-      
+
       var first_citizen_name = 'first-logger',
           second_citizen_name = 'second-logger',
           shutdowns_detected = 0,
@@ -462,8 +470,8 @@ describe('Supe Test Suite', function(){
         if( shutdowns_detected < 2 ) return;
 
         var detected_shutdown_from_both_citizens = shutdowns.indexOf( first_citizen_name ) > -1 && shutdowns.indexOf( second_citizen_name ) > -1;
-        
-        assert.equal( detected_shutdown_from_both_citizens, true, 'did not detect expected citizen shutdown' );        
+
+        assert.equal( detected_shutdown_from_both_citizens, true, 'did not detect expected citizen shutdown' );
         done();
       });
 
@@ -490,7 +498,7 @@ describe('Supe Test Suite', function(){
     it('sends notice "citizen-crashed" when any citizen crashes', function( done ){
 
       this.timeout( 15000 );
-      
+
       var first_citizen_name = 'first-crasher',
           second_citizen_name = 'second-crasher',
           crashes_detected = 0;
@@ -529,7 +537,7 @@ describe('Supe Test Suite', function(){
     it('sends notice "citizen-auto-restarted" when any crashed citizen is restarted', function( done ){
 
       this.timeout( 5000 );
-      
+
       var first_citizen_name = 'first-crasher',
           second_citizen_name = 'second-crasher',
           restarts_detected = 0;
@@ -540,7 +548,7 @@ describe('Supe Test Suite', function(){
 
         if( restarts_detected < 2 ) return;
 
-        assert.equal( restarts_detected === 2, true, 'did not detect all citizen restarts' );        
+        assert.equal( restarts_detected === 2, true, 'did not detect all citizen restarts' );
         done();
       });
 
@@ -662,7 +670,7 @@ describe('Supe Test Suite', function(){
 
       var name = 'unacker',
           message = 'CRASH',
-          citizen; 
+          citizen;
 
       supervisor.noticeboard.once( name + '-crashed', 'do-assertions', function( msg ){
 
@@ -683,7 +691,7 @@ describe('Supe Test Suite', function(){
 
       var name = 'unacker',
           message = 'SHUTDOWN',
-          citizen; 
+          citizen;
 
       supervisor.noticeboard.once( name + '-shutdown', 'do-assertions', function( msg ){
 
@@ -695,7 +703,7 @@ describe('Supe Test Suite', function(){
 
       citizen = supervisor.start( name, './test/citizen/unacked-mail', { retries: 0 });
 
-      citizen.mail.send( message ); 
+      citizen.mail.send( message );
     });
 
     it('will cache citizen notices', function( done ){
@@ -750,7 +758,7 @@ describe('Supe Test Suite', function(){
           var received_at = Date.now(),
               processed = received_at - paused_at;
 
-          assert.equal( processed >= pause_duration_ms, true, 'mail was processed in ' + processed + 'ms but pause duration is ' + pause_duration_ms + 'ms' );          
+          assert.equal( processed >= pause_duration_ms, true, 'mail was processed in ' + processed + 'ms but pause duration is ' + pause_duration_ms + 'ms' );
           done();
 
           // cleanup
@@ -767,7 +775,7 @@ describe('Supe Test Suite', function(){
 
   describe('Citizen Noticeboard Integration', function(){
     var supervisor;
-    
+
     beforeEach( function(){
       supervisor = supe({ retries: 0 });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -311,7 +311,35 @@ describe('Supe Test Suite', function(){
       });
     });
 
+    describe('Supervisor.stop', function(){
+      var supervisor,
+          new_process;
 
+      beforeEach( function(){
+        supervisor = supe();
+        new_process = supervisor.start( 'logger', './test/citizen/interval-logger' );
+      });
+
+      it('returns a Promsie', function( done ){
+        new_process
+        .then( () => {
+          assert.equal( supervisor.stop( 'logger' ) instanceof Promise, true, 'did not return a Promise' );
+          setTimeout( done, 0 );
+        } );
+      });
+
+      it('stops a process', function( done ){
+        new_process.then( ( citizen ) => {
+          assert.equal( citizen.hasOwnProperty( 'ref' ), true, 'citizen does not have ref property' );
+          supervisor.stop( 'logger' )
+          .then( ( new_citzen ) => {
+            assert.equal( new_citzen.hasOwnProperty( 'ref' ), false, 'citizen still has ref property' );
+            setTimeout( done, 0 );
+          } )
+          .catch( () => setTimeout( done, 0 ) );
+        });
+      });
+    });
 
     describe('Supervisor.get', function(){
       var supervisor = supe();

--- a/test/test.js
+++ b/test/test.js
@@ -243,6 +243,15 @@ describe('Supe Test Suite', function(){
         } )
         .catch( () => setTimeout( done, 0 ) );
       });
+
+      it('will fail to deregister a unregistered citizen', function( done ){
+        supervisor.deregister( 'unregistered-citizen' )
+        .then( () => {
+          assert.equal( false, true, 'deregistered a unregistered citizen' );
+          setTimeout( done, 0 ) ;
+        } )
+        .catch( () => setTimeout( done, 0 ) );
+      });
     });
 
     describe('Supervisor.start', function(){
@@ -296,7 +305,6 @@ describe('Supe Test Suite', function(){
       });
 
       it('will not restart a currently-running citizen', function( done ){
-
         new_process
         .then(() => {
           supervisor.start( 'logger' )
@@ -308,6 +316,18 @@ describe('Supe Test Suite', function(){
             setTimeout( done, 0 );
           } );
         });
+      });
+
+      it('will fail if file does not match registration', function( done ){
+        supervisor.register( 'custom-logger', './test/citizen/one-time-logger' )
+        .then( () => {
+          supervisor.start( 'custom-logger', 'bad-path' )
+          .then( () => {
+            assert.equal( false === true, true, 'started with a bad file path' );
+            setTimeout( done, 0 );
+          } )
+          .catch( () => setTimeout( done, 0 ) );
+        } );
       });
     });
 
@@ -337,6 +357,38 @@ describe('Supe Test Suite', function(){
             setTimeout( done, 0 );
           } )
           .catch( () => setTimeout( done, 0 ) );
+        });
+      });
+
+      it('fails to stop a unregistered citizen', function( done ){
+        supervisor.stop( 'unregistered-citizen' )
+        .then( ( ) => {
+          assert.equal( true, false, 'was able to stop a unregistered citizen' );
+          setTimeout( done, 0 );
+        } )
+        .catch( () => {
+          assert.equal( true, true );
+          setTimeout( done, 0 );
+        } );
+      });
+
+      it('not fail to stop a already stopped citizen', function( done ){
+        new_process.then( ( citizen ) => {
+          supervisor.stop( 'logger' )
+          .then( () => {
+            supervisor.stop( 'logger' )
+            .then( ( ) => {
+              assert.equal( true, true, 'was able to stop a citizen' );
+              setTimeout( done, 0 );
+            })
+            .catch( () => {
+              assert.equal( true, false, 'was not able to stop a already stopped citizen' );
+              setTimeout( done, 0 );
+            });
+          } )
+          .catch( () => {
+            assert.equal( true, false, 'was not able to stop a citizen' );
+          } );
         });
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -14,39 +14,44 @@ describe('Supe Test Suite', function(){
   describe('Supervisor (Instantiated Supe) Properties', function(){
 
     var supervisor = supe(),
-        expected_properties = [ 'is_registered', 'register', 'start', 'get', 'use', 'noticeboard', 'hook' ];
+        expected_properties = [
+          { key: 'is_registered', type: 'function' },
+          { key: 'deregister', type: 'function' },
+          { key: 'register', type: 'function' },
+          { key: 'start', type: 'function' },
+          { key: 'stop', type: 'function' },
+          { key: 'get', type: 'function' },
+          { key: 'use', type: 'function' },
+          { key: 'noticeboard', type: 'object' },
+          { key: 'hook', type: 'object' }
+        ],
+        expected_properties_index = [];
 
-    it('has its own "is_registered" function', function(){
-      assert.equal( supervisor.hasOwnProperty('is_registered') && typeof supervisor.is_registered === 'function', true, 'didn\'t instantiate with its own "is_registered" function');
-    });
+    expected_properties.forEach( function( prop ){
+      it( 'has its own "' + prop.key + '" ' + prop.type, function(){
+        assert.equal( supervisor.hasOwnProperty( prop.key ), true, 'has no "' + prop.key + '" property' );
 
-    it('has its own "register" function', function(){
-      assert.equal( supervisor.hasOwnProperty('register') && typeof supervisor.register === 'function', true, 'didn\'t instantiate with its own "register" function');
-    });
+        switch( prop.type ){
+          case 'function':
+            assert.equal( typeof supervisor[ prop.key ], 'function', '"' + prop.key + '" is not a function' );
+          break;
 
-    it('has its own "start" function', function(){
-      assert.equal( supervisor.hasOwnProperty('start') && typeof supervisor.start === 'function', true, 'didn\'t instantiate with its own "start" function');
-    });
+          case 'object':
+            assert.equal( Object.prototype.toString.call( supervisor[ prop.key ] ), '[object Object]', '"' + prop.key + '" is not a function' );
+          break;
 
-    it('has its own "get" function', function(){
-      assert.equal( supervisor.hasOwnProperty('get') && typeof supervisor.get === 'function', true, 'didn\'t instantiate with its own "get" function');
-    });
+          default:
+            throw new Error( 'no tests defined for '+ prop.type +' data-type' );
+          break;
+        }
 
-    it('has its own "use" function', function(){
-      assert.equal( supervisor.hasOwnProperty('use') && typeof supervisor.use === 'function', true, 'didn\'t instantiate with its own "get" function');
-    });
-
-    it('has its own "noticeboard" object', function(){
-      assert.equal( supervisor.hasOwnProperty('noticeboard') && Object.prototype.toString.call( supervisor.noticeboard ) === '[object Object]', true, 'didn\'t instantiate with its own "noticeboard" object');
-    });
-
-    it('has its own "hook" object', function(){
-      assert.equal( supervisor.hasOwnProperty('hook') && Object.prototype.toString.call( supervisor.hook ) === '[object Object]', true, 'didn\'t instantiate with its own "noticeboard" object');
+        expected_properties_index.push( prop.key );
+      });
     });
 
     it('has no unexpected properties', function(){
       for( var prop in supervisor ){
-        assert.equal( expected_properties.indexOf( prop ) > -1, true, 'has unexpected property "' + prop + '"' );
+        assert.equal( expected_properties_index.indexOf( prop ) > -1, true, 'has unexpected property "' + prop + '"' );
       }
     });
 


### PR DESCRIPTION
## New Supervisor APIs

`supervisor.stop`
- will stop a running instance of a citizen
- will give citizen a grace period to shut itself down cleanly
- if citizen exceeds grace period, it will be force-killed

`supervisor.deregister`
- will remove a citizen from supe's registry
- will stop a running citizen before removing it

## New Citizen Module

`hook`
- added hook as citizen core component

## New Citizen Hook

`shutdown`
- citizens can use this hook to shut down cleanly
- if the clean-up process isnt fully sync, hook provides a delay request system